### PR TITLE
Adds functions to lock and unlock encrypted volumes

### DIFF
--- a/Tests/qnap_tests.py
+++ b/Tests/qnap_tests.py
@@ -87,5 +87,11 @@ class UploadFileTestCase(unittest.TestCase):
         self.assertIsNotNone(upload_result)
         self.assertIsNotNone(upload_result['success'])
 
+class ListVolumesTestCase(unittest.TestCase):
+    def runTest(self):
+        volumes = filestation.get_volumes()
+        self.assertTrue(len(volumes) > 0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/qnap_tests.py
+++ b/Tests/qnap_tests.py
@@ -4,7 +4,7 @@ from qnap.filestation import FileStation
 
 logging.disable(logging.CRITICAL)
 
-host = 'usademo.myqnapcloud.com'
+host = 'usanasdemo.myqnapcloud.com'
 user = 'qnap'
 password = 'qnap'
 

--- a/Tests/qnap_tests.py
+++ b/Tests/qnap_tests.py
@@ -70,7 +70,7 @@ class DeleteFileTestCase(unittest.TestCase):
     def runTest(self):
         # The delete call will fail since the demo QNAP server is read-only
         delete_result = filestation.delete('/Multimedia/Sample/picture/sample001.jpg')
-        print delete_result
+        print(delete_result)
         self.assertIsNotNone(delete_result)
         self.assertIsNotNone(delete_result['success'])
 

--- a/filestation.py
+++ b/filestation.py
@@ -114,3 +114,29 @@ class FileStation(Qnap):
                 )
             }
         )
+
+    def unlock(self, volumeID, keyStr):
+        """
+        Unlock encrypted volume
+        """
+        return self.req_post(
+            self.endpoint(cgi='disk/disk_manage.cgi'),
+            data={
+                'func': 'open_encrypt_dev',
+                'volumeID': volumeID,
+                'keyStr': keyStr,
+                'saveKey': 'no'
+            }
+        )
+
+    def lock(self, volumeID):
+        """
+        Lock encrypted volume
+        """
+        return self.req_post(self.endpoint(cgi='disk/disk_manage.cgi'),
+            data={
+                'func': 'close_encrypt_dev',
+                'volumeID': volumeID,
+                'saveKey': 'no'
+            }
+        )

--- a/filestation.py
+++ b/filestation.py
@@ -1,4 +1,5 @@
 import os
+import xmltodict
 
 from qnap import Qnap
 
@@ -140,3 +141,26 @@ class FileStation(Qnap):
                 'saveKey': 'no'
             }
         )
+
+    def get_volumes(self):
+        """
+        Get list of volumes
+        """
+        resp = self.req(
+            self.endpoint(
+                cgi='management/chartReq.cgi',
+                params={
+                    'chart_func': 'disk_usage',
+                    'disk_select': 'all',
+                    'include': 'all'
+                }
+            ))
+
+        data = xmltodict.parse(resp, force_list=("volume"))['QDocRoot']
+        result={}
+        for vol in data['volumeList']['volume']:
+            key = vol["volumeValue"]
+            label = vol["volumeLabel"] if "volumeLabel" in vol else "Volume " + vol["volumeValue"]
+            result[key] = label
+
+        return result

--- a/qnap.py
+++ b/qnap.py
@@ -71,10 +71,10 @@ class Qnap():
         self.get_response_data(r)
         return None
 
-    def req_post(self, endpoint, files):
+    def req_post(self, endpoint, **kwargs):
         logging.info('url: ' + endpoint)
         try:
-            r = requests.post(endpoint, files=files)
+            r = requests.post(endpoint, **kwargs)
         except:
             logging.error('POST error: ' + endpoint)
             return None


### PR DESCRIPTION
QNAP encryption requires either (a) storing the encryption key in the NAS or (b) manually unlocking encrypted volumes via the web interface after each reboot.  Option (a) provides almost zero security (it only helps if someone steals your disks but not your NAS).  Option (b) is a pain.  This PR provides python bindings to allow remote unlocking by, for example, a script on a remote PC.

@mdhorda I don't know if you are still maintaining this repo but thought I'd raise the PR anyway.